### PR TITLE
fix: Truncate chunks exceeding maximum character limit

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -35,6 +35,7 @@ with st.sidebar:
 
 @st.cache_resource
 def load_chain():
+    """FAISS と BM25 のハイブリッドリトリーバーと LLM チェーンをロードして返す。"""
     if not os.path.exists(VECTORSTORE_PATH):
         return None, None
 

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ LLM_MODEL = "qwen2.5:7b"  # 14b に変えてもOK
 # チャンク設定
 CHUNK_SIZE = 300       # 細かくして一致しやすくする
 CHUNK_OVERLAP = 50
+MAX_CHUNK_CHARS = 1500  # コンテキスト長超過防止用の安全上限
 
 # 検索設定
 TOP_K = 6              # より多くの候補を拾う

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -36,6 +36,16 @@ def ingest():
     chunks = splitter.split_documents(docs)
     print(f"✅ {len(chunks)} チャンクに分割しました")
 
+    # モデルのコンテキスト長超過を防ぐため長すぎるチャンクを截断
+    MAX_CHUNK_CHARS = 1500
+    truncated = 0
+    for chunk in chunks:
+        if len(chunk.page_content) > MAX_CHUNK_CHARS:
+            chunk.page_content = chunk.page_content[:MAX_CHUNK_CHARS]
+            truncated += 1
+    if truncated:
+        print(f"⚠️  {truncated} チャンクを {MAX_CHUNK_CHARS} 文字に截断しました")
+
     # 3. ベクトル化 & 保存
     print(f"⏳ Embedding 中... (モデル: {EMBED_MODEL})")
     embeddings = OllamaEmbeddings(model=EMBED_MODEL)

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -6,12 +6,13 @@ import os
 import pickle
 from config import (
     OBSIDIAN_VAULT_PATH, VECTORSTORE_PATH, PROJECT_ROOT,
-    EMBED_MODEL, CHUNK_SIZE, CHUNK_OVERLAP
+    EMBED_MODEL, CHUNK_SIZE, CHUNK_OVERLAP, MAX_CHUNK_CHARS
 )
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 
 def ingest():
+    """Obsidian Vault を読み込み、チャンク分割してベクトルストアに保存する。"""
     print(f"📂 Vault パス: {OBSIDIAN_VAULT_PATH}")
 
     if not os.path.exists(OBSIDIAN_VAULT_PATH):
@@ -37,10 +38,10 @@ def ingest():
     print(f"✅ {len(chunks)} チャンクに分割しました")
 
     # モデルのコンテキスト長超過を防ぐため長すぎるチャンクを截断
-    MAX_CHUNK_CHARS = 1500
     truncated = 0
     for chunk in chunks:
         if len(chunk.page_content) > MAX_CHUNK_CHARS:
+            print(f"  截断: {chunk.metadata.get('source', 'unknown')} ({len(chunk.page_content)} -> {MAX_CHUNK_CHARS})")
             chunk.page_content = chunk.page_content[:MAX_CHUNK_CHARS]
             truncated += 1
     if truncated:

--- a/src/query.py
+++ b/src/query.py
@@ -17,9 +17,11 @@ PROMPT_TEMPLATE = """以下のコンテキストを参考に、質問に日本�
 回答:"""
 
 def format_docs(docs):
+    """ドキュメントのリストを改行区切りの文字列に整形する。"""
     return "\n\n".join(doc.page_content for doc in docs)
 
 def query(question: str):
+    """ベクトルストアを使って質問に回答する。"""
     if not os.path.exists(VECTORSTORE_PATH):
         print("❌ ベクトルストアが見つかりません。先に ingest.py を実行してください。")
         return


### PR DESCRIPTION
## Summary

- `ingest.py` のチャンク分割後に、1500文字を超えるチャンクを截断する処理を追加
- Obsidianノートの参照リンクに含まれる長いパーセントエンコードURLが `nomic-embed-text` のコンテキスト長を超え、embedding が `status code: 400` で失敗していた問題を修正

## Root Cause

`RecursiveCharacterTextSplitter` はスペースを区切りとして分割するが、URLにはスペースが含まれないため、`chunk_size=300` を設定していても単一URLが1チャンクとしてそのまま残ることがある。日本語のパーセントエンコードURL（例: `...%E3%83%90%E3%82%A6%E3%83%B3%E3%82%B9...`）は特に長くなりやすく、モデルのコンテキスト長を超過していた。

## Test plan

- [ ] `python src/ingest.py` を実行してエラーなく完了することを確認
- [ ] 截断ログ `⚠️ N チャンクを 1500 文字に截断しました` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a configurable max chunk length (1500 chars) and automatic truncation of oversized content during processing, with per-chunk messages and an aggregate warning before embedding to ensure stable downstream handling.
* **Documentation**
  * Added explanatory docstrings (including a Japanese description) to key loading and query-formatting routines for clearer developer-facing docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->