### PR TITLE
feat: Persist chat history with SQLite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest
+          pip install langchain langchain-community langchain-ollama langchain-text-splitters faiss-cpu rank_bm25
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.4.0
         with:
           python-version: "3.13"
 

--- a/src/app.py
+++ b/src/app.py
@@ -15,6 +15,24 @@ from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, TOP_K
 from db import init_db, create_session, list_sessions, delete_session, update_session_title, save_message, get_messages, build_export_content, export_filename
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
+DATA_DIR = os.path.join(PROJECT_ROOT, "data")
+
+
+def _assert_safe_path(path: str) -> None:
+    """ファイルパスがデータディレクトリ内の通常ファイルであることを検証する。
+
+    パストラバーサル・シンボリックリンク・ワールドライタブルを拒否する。
+    """
+    real = os.path.realpath(path)
+    data_real = os.path.realpath(DATA_DIR)
+    if not real.startswith(data_real + os.sep) and real != data_real:
+        raise ValueError(f"安全でないパス: {path}")
+    if os.path.islink(path):
+        raise ValueError(f"シンボリックリンクは許可されていません: {path}")
+    mode = os.stat(real).st_mode
+    if mode & 0o002:
+        raise ValueError(f"ワールドライタブルなファイルは読み込めません: {path}")
+
 
 PROMPT_TEMPLATE = """以下のコンテキストを参考に、質問に日本語で答えてください。
 コンテキストに情報がない場合は「ノートに該当する情報が見つかりませんでした」と答えてください。
@@ -37,6 +55,7 @@ def load_chain():
     if not os.path.exists(VECTORSTORE_PATH):
         return None, None
 
+    _assert_safe_path(VECTORSTORE_PATH)
     embeddings = OllamaEmbeddings(model=EMBED_MODEL)
     vectorstore = FAISS.load_local(
         VECTORSTORE_PATH, embeddings,
@@ -51,6 +70,7 @@ def load_chain():
     if os.path.exists(DOCS_CACHE_PATH):
         # docs_cache.pkl は ingest.py がローカルの Obsidian Vault から生成する
         # 信頼済みローカルファイルのため pickle デシリアライズは安全
+        _assert_safe_path(DOCS_CACHE_PATH)
         with open(DOCS_CACHE_PATH, "rb") as f:
             all_docs = pickle.load(f)
 

--- a/src/app.py
+++ b/src/app.py
@@ -12,8 +12,7 @@ from langchain_ollama import ChatOllama, OllamaEmbeddings
 
 sys.path.insert(0, os.path.dirname(__file__))
 from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K
-from db import init_db, create_session, list_sessions, delete_session, save_message, get_messages, build_export_content, export_filename
-from db.session_repo import update_session_title
+from db import init_db, create_session, list_sessions, delete_session, update_session_title, save_message, get_messages, build_export_content, export_filename
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 
@@ -50,6 +49,8 @@ def load_chain():
 
     bm25_retriever = None
     if os.path.exists(DOCS_CACHE_PATH):
+        # docs_cache.pkl は ingest.py がローカルの Obsidian Vault から生成する
+        # 信頼済みローカルファイルのため pickle デシリアライズは安全
         with open(DOCS_CACHE_PATH, "rb") as f:
             all_docs = pickle.load(f)
 
@@ -107,8 +108,10 @@ if not os.path.exists(DOCS_CACHE_PATH):
 chain, retriever = load_chain()
 
 # ── セッション初期化 ────────────────────────────────────────
+# 再起動後は直近セッションを復元し、存在しない場合のみ新規作成
 if "session_id" not in st.session_state:
-    st.session_state.session_id = create_session()
+    recent = list_sessions()
+    st.session_state.session_id = recent[0]["id"] if recent else create_session()
 
 # ── サイドバー：セッション一覧 ──────────────────────────────
 with st.sidebar:
@@ -147,7 +150,8 @@ with st.sidebar:
         if col2.button("🗑", key=f"del_{s['id']}"):
             delete_session(s["id"])
             if is_active:
-                st.session_state.session_id = create_session()
+                remaining = [x for x in sessions if x["id"] != s["id"]]
+                st.session_state.session_id = remaining[0]["id"] if remaining else create_session()
             st.rerun()
 
 # ── メインエリア ────────────────────────────────────────────

--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ from langchain_ollama import ChatOllama, OllamaEmbeddings
 
 sys.path.insert(0, os.path.dirname(__file__))
 from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K
-from db import init_db, create_session, list_sessions, delete_session, save_message, get_messages
+from db import init_db, create_session, list_sessions, delete_session, save_message, get_messages, build_export_content, export_filename
 from db.session_repo import update_session_title
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
@@ -120,9 +120,23 @@ with st.sidebar:
         st.rerun()
 
     st.divider()
+
+    # 現在のセッションをエクスポート
+    current_sessions = list_sessions()
+    current_title = next((s["title"] for s in current_sessions if s["id"] == st.session_state.session_id), "chat")
+    export_content = build_export_content(st.session_state.session_id, current_title)
+    st.download_button(
+        label="📥 エクスポート",
+        data=export_content.encode("utf-8"),
+        file_name=export_filename(),
+        mime="text/markdown",
+        use_container_width=True,
+    )
+
+    st.divider()
     st.markdown("#### 履歴")
 
-    sessions = list_sessions()
+    sessions = current_sessions
     for s in sessions:
         col1, col2 = st.columns([5, 1])
         is_active = s["id"] == st.session_state.session_id

--- a/src/app.py
+++ b/src/app.py
@@ -128,7 +128,7 @@ with st.sidebar:
     st.download_button(
         label="📥 エクスポート",
         data=export_content.encode("utf-8"),
-        file_name=export_filename(),
+        file_name=export_filename(),  # レンダリング時に確定、変数切り出し不要
         mime="text/markdown",
         use_container_width=True,
     )

--- a/src/app.py
+++ b/src/app.py
@@ -1,13 +1,21 @@
-import streamlit as st
-from langchain_ollama import OllamaEmbeddings, ChatOllama
-from langchain_community.vectorstores import FAISS
-from langchain_community.retrievers import BM25Retriever
-from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnablePassthrough
-from langchain_core.output_parsers import StrOutputParser
 import os
 import pickle
+import sys
+
+import streamlit as st
+from langchain_community.retrievers import BM25Retriever
+from langchain_community.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import PromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_ollama import ChatOllama, OllamaEmbeddings
+
+sys.path.insert(0, os.path.dirname(__file__))
 from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K
+from db import init_db, create_session, list_sessions, delete_session, save_message, get_messages
+from db.session_repo import update_session_title
+
+DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 
 PROMPT_TEMPLATE = """以下のコンテキストを参考に、質問に日本語で答えてください。
 コンテキストに情報がない場合は「ノートに該当する情報が見つかりませんでした」と答えてください。
@@ -18,20 +26,11 @@ PROMPT_TEMPLATE = """以下のコンテキストを参考に、質問に日本�
 質問: {question}
 回答:"""
 
-st.set_page_config(page_title="Obsidian RAG", page_icon="📓", layout="centered")
-st.title("📓 Obsidian ノート検索")
-st.caption(f"モデル: {LLM_MODEL}  |  Embedding: {EMBED_MODEL}  |  検索: ハイブリッド(BM25 + ベクトル)")
+# DB 初期化
+init_db()
 
-DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
+st.set_page_config(page_title="Obsidian RAG", page_icon="📓", layout="wide")
 
-# デバッグ用サイドバー
-with st.sidebar:
-    st.markdown("### 🔧 デバッグ情報")
-    st.code(f"PROJECT_ROOT:\n{PROJECT_ROOT}")
-    st.code(f"VECTORSTORE_PATH:\n{VECTORSTORE_PATH}")
-    st.code(f"DOCS_CACHE_PATH:\n{DOCS_CACHE_PATH}")
-    st.write("vectorstore 存在:", os.path.exists(VECTORSTORE_PATH))
-    st.write("docs_cache 存在:", os.path.exists(DOCS_CACHE_PATH))
 
 @st.cache_resource
 def load_chain():
@@ -42,22 +41,22 @@ def load_chain():
     embeddings = OllamaEmbeddings(model=EMBED_MODEL)
     vectorstore = FAISS.load_local(
         VECTORSTORE_PATH, embeddings,
-        allow_dangerous_deserialization=True
+        allow_dangerous_deserialization=True,
     )
     faiss_retriever = vectorstore.as_retriever(
         search_type="mmr",
-        search_kwargs={"k": TOP_K, "fetch_k": FETCH_K}
+        search_kwargs={"k": TOP_K, "fetch_k": FETCH_K},
     )
 
-    # BM25 リトリーバー（キャッシュから復元）
     bm25_retriever = None
     if os.path.exists(DOCS_CACHE_PATH):
         with open(DOCS_CACHE_PATH, "rb") as f:
             all_docs = pickle.load(f)
-        # 日本語対応：文字レベルのトークナイズ（スペース区切りでは日本語に効かないため）
+
         def japanese_tokenizer(text: str):
+            """日本語テキストを文字・バイグラム単位でトークナイズする。"""
             chars = list(text)
-            bigrams = ["".join(chars[i:i+2]) for i in range(len(chars) - 1)]
+            bigrams = ["".join(chars[i:i + 2]) for i in range(len(chars) - 1)]
             return chars + bigrams
 
         bm25_retriever = BM25Retriever.from_documents(
@@ -66,11 +65,11 @@ def load_chain():
         bm25_retriever.k = TOP_K
 
     def hybrid_retrieve(question: str):
+        """BM25 と FAISS の結果をマージして重複除去したドキュメントリストを返す。"""
         faiss_docs = faiss_retriever.invoke(question)
         if bm25_retriever is None:
             return faiss_docs
         bm25_docs = bm25_retriever.invoke(question)
-        # 重複除去しながらマージ
         seen, combined = set(), []
         for doc in bm25_docs + faiss_docs:
             key = doc.page_content[:80]
@@ -79,15 +78,15 @@ def load_chain():
                 combined.append(doc)
         return combined[:TOP_K]
 
+    def format_docs(docs):
+        """ドキュメントのリストを改行区切りの文字列に整形する。"""
+        return "\n\n".join(doc.page_content for doc in docs)
+
     llm = ChatOllama(model=LLM_MODEL, temperature=0.1)
     prompt = PromptTemplate(
         template=PROMPT_TEMPLATE,
-        input_variables=["context", "question"]
+        input_variables=["context", "question"],
     )
-
-    def format_docs(docs):
-        return "\n\n".join(doc.page_content for doc in docs)
-
     chain = (
         {"context": lambda q: format_docs(hybrid_retrieve(q)), "question": RunnablePassthrough()}
         | prompt
@@ -96,7 +95,8 @@ def load_chain():
     )
     return chain, hybrid_retrieve
 
-# ベクトルストアの存在チェック
+
+# ── ベクトルストア存在チェック ──────────────────────────────
 if not os.path.exists(VECTORSTORE_PATH):
     st.error("ベクトルストアが見つかりません。先に `python ingest.py` を実行してください。")
     st.stop()
@@ -106,20 +106,54 @@ if not os.path.exists(DOCS_CACHE_PATH):
 
 chain, retriever = load_chain()
 
-# チャット履歴の初期化
-if "messages" not in st.session_state:
-    st.session_state.messages = []
+# ── セッション初期化 ────────────────────────────────────────
+if "session_id" not in st.session_state:
+    st.session_state.session_id = create_session()
 
-# チャット履歴の表示
-for msg in st.session_state.messages:
+# ── サイドバー：セッション一覧 ──────────────────────────────
+with st.sidebar:
+    st.title("📓 Obsidian RAG")
+    st.caption(f"モデル: {LLM_MODEL} | Embedding: {EMBED_MODEL}")
+
+    if st.button("＋ 新しいチャット", use_container_width=True):
+        st.session_state.session_id = create_session()
+        st.rerun()
+
+    st.divider()
+    st.markdown("#### 履歴")
+
+    sessions = list_sessions()
+    for s in sessions:
+        col1, col2 = st.columns([5, 1])
+        is_active = s["id"] == st.session_state.session_id
+        label = f"**{s['title']}**" if is_active else s["title"]
+        if col1.button(label, key=f"sel_{s['id']}", use_container_width=True):
+            st.session_state.session_id = s["id"]
+            st.rerun()
+        if col2.button("🗑", key=f"del_{s['id']}"):
+            delete_session(s["id"])
+            if is_active:
+                st.session_state.session_id = create_session()
+            st.rerun()
+
+# ── メインエリア ────────────────────────────────────────────
+st.title("📓 Obsidian ノート検索")
+
+# DB からメッセージ復元
+messages = get_messages(st.session_state.session_id)
+for msg in messages:
     with st.chat_message(msg["role"]):
         st.markdown(msg["content"])
 
 # 入力欄
 if question := st.chat_input("Obsidian ノートに質問する..."):
-    st.session_state.messages.append({"role": "user", "content": question})
+    save_message(st.session_state.session_id, "user", question)
     with st.chat_message("user"):
         st.markdown(question)
+
+    # 最初のメッセージをセッションタイトルに使用
+    if len(messages) == 0:
+        update_session_title(st.session_state.session_id, question[:40])
 
     source_docs = retriever(question)
 
@@ -136,4 +170,4 @@ if question := st.chat_input("Obsidian ノートに質問する..."):
                 st.text(doc.page_content[:300] + "..." if len(doc.page_content) > 300 else doc.page_content)
                 st.divider()
 
-    st.session_state.messages.append({"role": "assistant", "content": answer})
+    save_message(st.session_state.session_id, "assistant", answer)

--- a/src/config.py
+++ b/src/config.py
@@ -21,3 +21,6 @@ MAX_CHUNK_CHARS = 1500  # コンテキスト長超過防止用の安全上限
 # 検索設定
 TOP_K = 6              # より多くの候補を拾う
 FETCH_K = 20           # MMR の候補プール数（多いほど多様性UP）
+
+# DB設定
+DB_PATH = os.path.join(PROJECT_ROOT, "data", "chat.db")

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,6 +1,6 @@
 from .connection import get_connection
 from .models import init_db
-from .session_repo import create_session, list_sessions, delete_session
+from .session_repo import create_session, list_sessions, delete_session, update_session_title
 from .message_repo import save_message, get_messages
 from .export import build_export_content, export_filename
 
@@ -10,6 +10,7 @@ __all__ = [
     "create_session",
     "list_sessions",
     "delete_session",
+    "update_session_title",
     "save_message",
     "get_messages",
     "build_export_content",

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -5,14 +5,14 @@ from .message_repo import save_message, get_messages
 from .export import build_export_content, export_filename
 
 __all__ = [
-    "get_connection",
-    "init_db",
-    "create_session",
-    "list_sessions",
-    "delete_session",
-    "update_session_title",
-    "save_message",
-    "get_messages",
     "build_export_content",
+    "create_session",
+    "delete_session",
     "export_filename",
+    "get_connection",
+    "get_messages",
+    "init_db",
+    "list_sessions",
+    "save_message",
+    "update_session_title",
 ]

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,14 @@
+from .connection import get_connection
+from .models import init_db
+from .session_repo import create_session, list_sessions, delete_session
+from .message_repo import save_message, get_messages
+
+__all__ = [
+    "get_connection",
+    "init_db",
+    "create_session",
+    "list_sessions",
+    "delete_session",
+    "save_message",
+    "get_messages",
+]

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -2,6 +2,7 @@ from .connection import get_connection
 from .models import init_db
 from .session_repo import create_session, list_sessions, delete_session
 from .message_repo import save_message, get_messages
+from .export import build_export_content, export_filename
 
 __all__ = [
     "get_connection",
@@ -11,4 +12,6 @@ __all__ = [
     "delete_session",
     "save_message",
     "get_messages",
+    "build_export_content",
+    "export_filename",
 ]

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -1,0 +1,14 @@
+import sqlite3
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from config import DB_PATH
+
+
+def get_connection() -> sqlite3.Connection:
+    """DB接続を返す。Row オブジェクトで列名アクセスを有効にする。"""
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn

--- a/src/db/export.py
+++ b/src/db/export.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from .message_repo import get_messages
-from .session_repo import list_sessions
 
 
 def build_export_content(session_id: str, title: str) -> str:

--- a/src/db/export.py
+++ b/src/db/export.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from .message_repo import get_messages
+from .session_repo import list_sessions
+
+
+def build_export_content(session_id: str, title: str) -> str:
+    """セッションのメッセージを Markdown 形式の文字列に変換する。"""
+    messages = get_messages(session_id)
+    lines = [f"# {title}", ""]
+    for msg in messages:
+        role_label = "**You**" if msg["role"] == "user" else "**Assistant**"
+        lines.append(f"{role_label}  ")
+        lines.append(msg["content"])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def export_filename(prefix: str = "claude_chat") -> str:
+    """現在時刻を使ったエクスポートファイル名を返す（例: 202603281205_claude_chat.md）。"""
+    timestamp = datetime.now().strftime("%Y%m%d%H%M")
+    return f"{timestamp}_{prefix}.md"

--- a/src/db/message_repo.py
+++ b/src/db/message_repo.py
@@ -15,7 +15,7 @@ def get_messages(session_id: str) -> list[dict]:
     with get_connection() as conn:
         rows = conn.execute(
             "SELECT role, content, created_at FROM messages "
-            "WHERE session_id = ? ORDER BY created_at ASC",
+            "WHERE session_id = ? ORDER BY created_at ASC, id ASC",
             (session_id,),
         ).fetchall()
     return [dict(row) for row in rows]

--- a/src/db/message_repo.py
+++ b/src/db/message_repo.py
@@ -1,0 +1,21 @@
+from .connection import get_connection
+
+
+def save_message(session_id: str, role: str, content: str) -> None:
+    """メッセージを DB に保存する。role は 'user' または 'assistant'。"""
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content) VALUES (?, ?, ?)",
+            (session_id, role, content),
+        )
+
+
+def get_messages(session_id: str) -> list[dict]:
+    """指定セッションのメッセージを時系列順で返す。"""
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT role, content, created_at FROM messages "
+            "WHERE session_id = ? ORDER BY created_at ASC",
+            (session_id,),
+        ).fetchall()
+    return [dict(row) for row in rows]

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -4,21 +4,23 @@ from .connection import get_connection
 def init_db() -> None:
     """テーブルが存在しない場合に作成する（冪等）。"""
     with get_connection() as conn:
-        conn.executescript("""
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS sessions (
                 id         TEXT PRIMARY KEY,
                 title      TEXT NOT NULL DEFAULT '新しいチャット',
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-            );
-
+            )
+        """)
+        conn.execute("""
             CREATE TABLE IF NOT EXISTS messages (
                 id         INTEGER PRIMARY KEY AUTOINCREMENT,
                 session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
                 role       TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
                 content    TEXT NOT NULL,
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-            );
-
+            )
+        """)
+        conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_messages_session_id
-                ON messages(session_id);
+                ON messages(session_id)
         """)

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -1,0 +1,24 @@
+from .connection import get_connection
+
+
+def init_db() -> None:
+    """テーブルが存在しない場合に作成する（冪等）。"""
+    with get_connection() as conn:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                id         TEXT PRIMARY KEY,
+                title      TEXT NOT NULL DEFAULT '新しいチャット',
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS messages (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                role       TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+                content    TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_messages_session_id
+                ON messages(session_id);
+        """)

--- a/src/db/session_repo.py
+++ b/src/db/session_repo.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+from .connection import get_connection
+
+
+def create_session(title: Optional[str] = None) -> str:
+    """新しいセッションを作成し、セッション ID を返す。"""
+    session_id = str(uuid.uuid4())
+    session_title = title or f"チャット {datetime.now().strftime('%Y-%m-%d %H:%M')}"
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO sessions (id, title) VALUES (?, ?)",
+            (session_id, session_title),
+        )
+    return session_id
+
+
+def list_sessions() -> list[dict]:
+    """全セッションを新しい順で返す。"""
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT id, title, created_at FROM sessions ORDER BY created_at DESC, rowid DESC"
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def update_session_title(session_id: str, title: str) -> None:
+    """セッションのタイトルを更新する。"""
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = ?",
+            (title, session_id),
+        )
+
+
+def delete_session(session_id: str) -> None:
+    """セッションと関連メッセージを削除する。"""
+    with get_connection() as conn:
+        conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import tempfile
+import pytest
+
+# src/ を import パスに追加
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+@pytest.fixture
+def tmp_db(monkeypatch, tmp_path):
+    """テスト用に一時 DB ファイルを使うよう config を差し替える。"""
+    db_path = str(tmp_path / "test_chat.db")
+    monkeypatch.setattr("config.DB_PATH", db_path)
+
+    # connection モジュールも差し替え
+    import db.connection as conn_mod
+    monkeypatch.setattr(conn_mod, "DB_PATH", db_path)
+
+    from db.models import init_db
+    init_db()
+    return db_path

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,47 @@
+import re
+from db.session_repo import create_session
+from db.message_repo import save_message
+from db.export import build_export_content, export_filename
+
+
+def test_export_filename_format(tmp_db):
+    name = export_filename()
+    assert re.match(r"^\d{12}_claude_chat\.md$", name)
+
+
+def test_export_filename_custom_prefix(tmp_db):
+    name = export_filename(prefix="my_export")
+    assert name.endswith("_my_export.md")
+
+
+def test_build_export_content_structure(tmp_db):
+    session_id = create_session(title="テストセッション")
+    save_message(session_id, "user", "こんにちは")
+    save_message(session_id, "assistant", "はい、何でしょう？")
+
+    content = build_export_content(session_id, "テストセッション")
+    assert "# テストセッション" in content
+    assert "**You**" in content
+    assert "こんにちは" in content
+    assert "**Assistant**" in content
+    assert "はい、何でしょう？" in content
+
+
+def test_build_export_content_empty_session(tmp_db):
+    session_id = create_session(title="空セッション")
+    content = build_export_content(session_id, "空セッション")
+    assert "# 空セッション" in content
+    assert "**You**" not in content
+
+
+def test_build_export_content_message_order(tmp_db):
+    session_id = create_session()
+    save_message(session_id, "user", "1番目")
+    save_message(session_id, "assistant", "2番目")
+    save_message(session_id, "user", "3番目")
+
+    content = build_export_content(session_id, "順序テスト")
+    pos1 = content.index("1番目")
+    pos2 = content.index("2番目")
+    pos3 = content.index("3番目")
+    assert pos1 < pos2 < pos3

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -4,12 +4,12 @@ from db.message_repo import save_message
 from db.export import build_export_content, export_filename
 
 
-def test_export_filename_format(tmp_db):
+def test_export_filename_format():
     name = export_filename()
     assert re.match(r"^\d{12}_claude_chat\.md$", name)
 
 
-def test_export_filename_custom_prefix(tmp_db):
+def test_export_filename_custom_prefix():
     name = export_filename(prefix="my_export")
     assert name.endswith("_my_export.md")
 

--- a/tests/test_message_repo.py
+++ b/tests/test_message_repo.py
@@ -1,0 +1,55 @@
+import pytest
+from db.session_repo import create_session, delete_session
+from db.message_repo import save_message, get_messages
+
+
+def test_save_and_get_messages(tmp_db):
+    session_id = create_session()
+    save_message(session_id, "user", "こんにちは")
+    save_message(session_id, "assistant", "はい、何でしょう？")
+
+    messages = get_messages(session_id)
+    assert len(messages) == 2
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "こんにちは"
+    assert messages[1]["role"] == "assistant"
+
+
+def test_get_messages_order(tmp_db):
+    session_id = create_session()
+    save_message(session_id, "user", "1番目")
+    save_message(session_id, "assistant", "2番目")
+    save_message(session_id, "user", "3番目")
+
+    messages = get_messages(session_id)
+    assert [m["content"] for m in messages] == ["1番目", "2番目", "3番目"]
+
+
+def test_get_messages_empty(tmp_db):
+    session_id = create_session()
+    assert get_messages(session_id) == []
+
+
+def test_messages_isolated_per_session(tmp_db):
+    id1 = create_session()
+    id2 = create_session()
+    save_message(id1, "user", "セッション1のメッセージ")
+    save_message(id2, "user", "セッション2のメッセージ")
+
+    assert len(get_messages(id1)) == 1
+    assert len(get_messages(id2)) == 1
+    assert get_messages(id1)[0]["content"] == "セッション1のメッセージ"
+
+
+def test_delete_session_cascades_messages(tmp_db):
+    session_id = create_session()
+    save_message(session_id, "user", "消えるメッセージ")
+    delete_session(session_id)
+    # セッション削除でメッセージも CASCADE 削除される
+    assert get_messages(session_id) == []
+
+
+def test_invalid_role_raises(tmp_db):
+    session_id = create_session()
+    with pytest.raises(Exception):
+        save_message(session_id, "invalid_role", "テスト")

--- a/tests/test_message_repo.py
+++ b/tests/test_message_repo.py
@@ -1,3 +1,4 @@
+import sqlite3
 import pytest
 from db.session_repo import create_session, delete_session
 from db.message_repo import save_message, get_messages
@@ -51,5 +52,5 @@ def test_delete_session_cascades_messages(tmp_db):
 
 def test_invalid_role_raises(tmp_db):
     session_id = create_session()
-    with pytest.raises(Exception):
+    with pytest.raises(sqlite3.IntegrityError):
         save_message(session_id, "invalid_role", "テスト")

--- a/tests/test_session_repo.py
+++ b/tests/test_session_repo.py
@@ -1,0 +1,52 @@
+import pytest
+from db.session_repo import create_session, list_sessions, update_session_title, delete_session
+
+
+def test_create_session_returns_uuid(tmp_db):
+    session_id = create_session()
+    assert len(session_id) == 36  # UUID4 形式
+    assert "-" in session_id
+
+
+def test_create_session_with_title(tmp_db):
+    session_id = create_session(title="テストセッション")
+    sessions = list_sessions()
+    assert sessions[0]["title"] == "テストセッション"
+    assert sessions[0]["id"] == session_id
+
+
+def test_create_session_default_title(tmp_db):
+    create_session()
+    sessions = list_sessions()
+    assert "チャット" in sessions[0]["title"]
+
+
+def test_list_sessions_order(tmp_db):
+    id1 = create_session(title="first")
+    id2 = create_session(title="second")
+    sessions = list_sessions()
+    # 新しい順なので second が先頭
+    assert sessions[0]["id"] == id2
+    assert sessions[1]["id"] == id1
+
+
+def test_list_sessions_empty(tmp_db):
+    assert list_sessions() == []
+
+
+def test_update_session_title(tmp_db):
+    session_id = create_session(title="旧タイトル")
+    update_session_title(session_id, "新タイトル")
+    sessions = list_sessions()
+    assert sessions[0]["title"] == "新タイトル"
+
+
+def test_delete_session(tmp_db):
+    session_id = create_session()
+    delete_session(session_id)
+    assert list_sessions() == []
+
+
+def test_delete_nonexistent_session(tmp_db):
+    # 存在しない ID を削除してもエラーにならない
+    delete_session("nonexistent-id")


### PR DESCRIPTION
## Summary

- `src/db/` モジュールを追加し、SQLite でチャット履歴を永続化
- リロード・サーバー再起動後もセッション別に履歴を復元
- サイドバーで過去セッションの切り替え・削除が可能

## Changes

- `src/db/connection.py` — DB 接続管理（`PRAGMA foreign_keys = ON`）
- `src/db/models.py` — テーブル定義・マイグレーション（`sessions`, `messages`）
- `src/db/session_repo.py` — セッション CRUD
- `src/db/message_repo.py` — メッセージ CRUD
- `src/config.py` — `DB_PATH` 追加
- `src/app.py` — DB を使った履歴保存・復元、サイドバーセッション一覧

## Test plan

- [x] `tests/test_session_repo.py` — 8 tests passing
- [x] `tests/test_message_repo.py` — 6 tests passing
- [x] CASCADE 削除（セッション削除でメッセージも削除）
- [x] セッション順序（新しい順）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat sessions persist across restarts and restore full message history
  * Sidebar session manager: create, switch, and delete conversations
  * Export current session as a downloadable Markdown file
  * Wider app layout for improved visibility

* **Behavior**
  * Session titles are set from the first message when a session is new

* **Tests & CI**
  * Added unit/integration tests for session/message/export behavior and a CI workflow to run them
<!-- end of auto-generated comment: release notes by coderabbit.ai -->