### PR TITLE
refactor: Extract RAG pipeline from app.py into rag.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,18 +1,13 @@
 import os
-import pickle
 import sys
 
 import streamlit as st
-from langchain_community.retrievers import BM25Retriever
-from langchain_community.vectorstores import FAISS
 from langchain_core.messages import HumanMessage, AIMessage
-from langchain_core.output_parsers import StrOutputParser
-from langchain_ollama import ChatOllama, OllamaEmbeddings
 
 sys.path.insert(0, os.path.dirname(__file__))
-from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K, CHAT_HISTORY_TURNS
+from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, CHAT_HISTORY_TURNS
 from db import init_db, create_session, list_sessions, delete_session, update_session_title, get_messages, AppChatMessageHistory, build_export_content, export_filename
-from prompts import CONTEXTUALIZE_PROMPT, QA_PROMPT
+import rag
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 DATA_DIR = os.path.join(PROJECT_ROOT, "data")
@@ -34,15 +29,6 @@ def _assert_safe_path(path: str) -> None:
         raise ValueError(f"ワールドライタブルなファイルは読み込めません: {path}")
 
 
-def format_docs(docs) -> str:
-    """ドキュメントをソース名付きの構造化テキストに整形する。"""
-    chunks = []
-    for i, doc in enumerate(docs, 1):
-        source = os.path.basename(doc.metadata.get("source", "unknown"))
-        chunks.append(f"=== Source {i}: {source} ===\n{doc.page_content}\n---")
-    return "\n\n".join(chunks)
-
-
 # DB 初期化
 init_db()
 
@@ -50,57 +36,12 @@ st.set_page_config(page_title="Obsidian RAG", page_icon="📓", layout="wide")
 
 
 @st.cache_resource
-def load_resources():
-    """FAISS・BM25・LLM をロードしてキャッシュする。"""
-    if not os.path.exists(VECTORSTORE_PATH):
-        return None, None
-
+def _load_cached_resources():
+    """パス検証後に RAG リソースをロードしてキャッシュする。"""
     _assert_safe_path(VECTORSTORE_PATH)
-    embeddings = OllamaEmbeddings(model=EMBED_MODEL)
-    vectorstore = FAISS.load_local(
-        VECTORSTORE_PATH, embeddings,
-        allow_dangerous_deserialization=True,
-    )
-    faiss_retriever = vectorstore.as_retriever(
-        search_type="mmr",
-        search_kwargs={"k": TOP_K, "fetch_k": FETCH_K},
-    )
-
-    bm25_retriever = None
     if os.path.exists(DOCS_CACHE_PATH):
-        # docs_cache.pkl は ingest.py がローカルの Obsidian Vault から生成する
-        # 信頼済みローカルファイルのため pickle デシリアライズは安全
         _assert_safe_path(DOCS_CACHE_PATH)
-        with open(DOCS_CACHE_PATH, "rb") as f:
-            all_docs = pickle.load(f)
-
-        def japanese_tokenizer(text: str):
-            """日本語テキストを文字・バイグラム単位でトークナイズする。"""
-            chars = list(text)
-            bigrams = ["".join(chars[i:i + 2]) for i in range(len(chars) - 1)]
-            return chars + bigrams
-
-        bm25_retriever = BM25Retriever.from_documents(
-            all_docs, preprocess_func=japanese_tokenizer
-        )
-        bm25_retriever.k = TOP_K
-
-    def hybrid_retrieve(question: str):
-        """BM25 と FAISS の結果をマージして重複除去したドキュメントリストを返す。"""
-        faiss_docs = faiss_retriever.invoke(question)
-        if bm25_retriever is None:
-            return faiss_docs
-        bm25_docs = bm25_retriever.invoke(question)
-        seen, combined = set(), []
-        for doc in bm25_docs + faiss_docs:
-            key = doc.page_content[:80]
-            if key not in seen:
-                seen.add(key)
-                combined.append(doc)
-        return combined[:TOP_K]
-
-    llm = ChatOllama(model=LLM_MODEL, temperature=0.1)
-    return llm, hybrid_retrieve
+    return rag.load_resources(VECTORSTORE_PATH, DOCS_CACHE_PATH)
 
 
 # ── ベクトルストア存在チェック ──────────────────────────────
@@ -111,7 +52,7 @@ if not os.path.exists(VECTORSTORE_PATH):
 if not os.path.exists(DOCS_CACHE_PATH):
     st.warning("BM25用のキャッシュがありません。`python ingest.py` を再実行してください。")
 
-llm, hybrid_retrieve = load_resources()
+llm, hybrid_retrieve = _load_cached_resources()
 if llm is None:
     st.error("リソースのロードに失敗しました。`python ingest.py` を実行してください。")
     st.stop()
@@ -175,7 +116,7 @@ for msg in messages:
 # 入力欄
 if question := st.chat_input("Obsidian ノートに質問する..."):
     history = AppChatMessageHistory(st.session_state.session_id, max_turns=CHAT_HISTORY_TURNS)
-    chat_history = history.messages  # 現在の履歴を取得（今回の質問は含まない）
+    chat_history = history.messages
     is_first_message = len(chat_history) == 0
 
     with st.chat_message("user"):
@@ -185,33 +126,22 @@ if question := st.chat_input("Obsidian ノートに質問する..."):
         update_session_title(st.session_state.session_id, question[:40])
 
     with st.chat_message("assistant"):
-        # Step 1: 会話履歴がある場合はフォローアップ質問を単独の質問に言い換え
         if chat_history:
             with st.spinner("質問を解析中..."):
-                search_query = (CONTEXTUALIZE_PROMPT | llm | StrOutputParser()).invoke(
-                    {"input": question, "chat_history": chat_history}
-                )
+                search_query = rag.contextualize_query(llm, question, chat_history)
         else:
             search_query = question
 
-        # Step 2: 言い換えた質問でハイブリッド検索
         with st.spinner("ノートを検索中..."):
             source_docs = hybrid_retrieve(search_query)
 
-        # Step 3: 回答をストリーミング出力
         answer = ""
         try:
-            answer = st.write_stream(
-                (QA_PROMPT | llm | StrOutputParser()).stream(
-                    {"input": question, "chat_history": chat_history, "context": format_docs(source_docs)}
-                )
-            )
+            answer = st.write_stream(rag.stream_answer(llm, question, chat_history, source_docs))
         except Exception:
             st.error("回答の生成に失敗しました。Ollama が起動しているか確認してください。")
             raise
         finally:
-            # ストリーミング成否に関わらずユーザーメッセージを保存
-            # 回答が得られた場合はアシスタントメッセージも保存
             history.add_message(HumanMessage(content=question))
             if answer:
                 history.add_message(AIMessage(content=answer))

--- a/src/app.py
+++ b/src/app.py
@@ -10,23 +10,6 @@ from db import init_db, create_session, list_sessions, delete_session, update_se
 import rag
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
-DATA_DIR = os.path.join(PROJECT_ROOT, "data")
-
-
-def _assert_safe_path(path: str) -> None:
-    """ファイルパスがデータディレクトリ内の通常ファイルであることを検証する。
-
-    パストラバーサル・シンボリックリンク・ワールドライタブルを拒否する。
-    """
-    real = os.path.realpath(path)
-    data_real = os.path.realpath(DATA_DIR)
-    if not real.startswith(data_real + os.sep) and real != data_real:
-        raise ValueError(f"安全でないパス: {path}")
-    if os.path.islink(path):
-        raise ValueError(f"シンボリックリンクは許可されていません: {path}")
-    mode = os.stat(real).st_mode
-    if mode & 0o002:
-        raise ValueError(f"ワールドライタブルなファイルは読み込めません: {path}")
 
 
 # DB 初期化
@@ -37,10 +20,7 @@ st.set_page_config(page_title="Obsidian RAG", page_icon="📓", layout="wide")
 
 @st.cache_resource
 def _load_cached_resources():
-    """パス検証後に RAG リソースをロードしてキャッシュする。"""
-    _assert_safe_path(VECTORSTORE_PATH)
-    if os.path.exists(DOCS_CACHE_PATH):
-        _assert_safe_path(DOCS_CACHE_PATH)
+    """RAG リソースをロードしてキャッシュする。パス検証は load_resources() 内で実施。"""
     return rag.load_resources(VECTORSTORE_PATH, DOCS_CACHE_PATH, allow_deserialization=True)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -41,7 +41,7 @@ def _load_cached_resources():
     _assert_safe_path(VECTORSTORE_PATH)
     if os.path.exists(DOCS_CACHE_PATH):
         _assert_safe_path(DOCS_CACHE_PATH)
-    return rag.load_resources(VECTORSTORE_PATH, DOCS_CACHE_PATH)
+    return rag.load_resources(VECTORSTORE_PATH, DOCS_CACHE_PATH, allow_deserialization=True)
 
 
 # ── ベクトルストア存在チェック ──────────────────────────────

--- a/src/query.py
+++ b/src/query.py
@@ -1,24 +1,11 @@
-import os
 import sys
+import os
 
-from langchain_ollama import OllamaEmbeddings, ChatOllama
-from langchain_community.vectorstores import FAISS
-from langchain_core.output_parsers import StrOutputParser
-
-from config import VECTORSTORE_PATH, EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K
-from prompts import CONTEXTUALIZE_PROMPT, QA_PROMPT
+from config import VECTORSTORE_PATH
+import rag
 
 
-def format_docs(docs):
-    """ドキュメントをソース名付きの構造化テキストに整形する。"""
-    chunks = []
-    for i, doc in enumerate(docs, 1):
-        source = os.path.basename(doc.metadata.get("source", "unknown"))
-        chunks.append(f"=== Source {i}: {source} ===\n{doc.page_content}\n---")
-    return "\n\n".join(chunks)
-
-
-def query(question: str):
+def query(question: str) -> None:
     """ベクトルストアを使って質問に回答する（CLI 用・履歴なし）。"""
     if not os.path.exists(VECTORSTORE_PATH):
         print("❌ ベクトルストアが見つかりません。先に ingest.py を実行してください。")
@@ -26,23 +13,12 @@ def query(question: str):
 
     print(f"🔍 質問: {question}\n")
 
-    embeddings = OllamaEmbeddings(model=EMBED_MODEL)
-    vectorstore = FAISS.load_local(
-        VECTORSTORE_PATH, embeddings,
-        allow_dangerous_deserialization=True
-    )
-    retriever = vectorstore.as_retriever(
-        search_type="mmr",
-        search_kwargs={"k": TOP_K, "fetch_k": FETCH_K}
-    )
-    llm = ChatOllama(model=LLM_MODEL, temperature=0.1)
-
-    docs = retriever.invoke(question)
-    answer = (QA_PROMPT | llm | StrOutputParser()).invoke(
-        {"input": question, "chat_history": [], "context": format_docs(docs)}
-    )
+    llm, retrieve = rag.load_resources(VECTORSTORE_PATH)
+    docs = retrieve(question)
     print("💬 回答:")
-    print(answer)
+    for chunk in rag.stream_answer(llm, question, [], docs):
+        print(chunk, end="", flush=True)
+    print()
 
 
 if __name__ == "__main__":

--- a/src/query.py
+++ b/src/query.py
@@ -1,8 +1,10 @@
 import sys
 import os
 
-from config import VECTORSTORE_PATH
+from config import VECTORSTORE_PATH, PROJECT_ROOT
 import rag
+
+DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 
 
 def query(question: str) -> None:
@@ -13,7 +15,9 @@ def query(question: str) -> None:
 
     print(f"🔍 質問: {question}\n")
 
-    llm, retrieve = rag.load_resources(VECTORSTORE_PATH)
+    llm, retrieve = rag.load_resources(
+        VECTORSTORE_PATH, DOCS_CACHE_PATH, allow_deserialization=True
+    )
     docs = retrieve(question)
     print("💬 回答:")
     for chunk in rag.stream_answer(llm, question, [], docs):

--- a/src/query.py
+++ b/src/query.py
@@ -8,7 +8,7 @@ DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 
 
 def query(question: str) -> None:
-    """ベクトルストアを使って質問に回答する（CLI 用・履歴なし）。"""
+    """ベクトルストアを使って質問に回答する (CLI 用・履歴なし)。"""
     if not os.path.exists(VECTORSTORE_PATH):
         print("❌ ベクトルストアが見つかりません。先に ingest.py を実行してください。")
         return

--- a/src/rag.py
+++ b/src/rag.py
@@ -27,9 +27,10 @@ def _merge_results(bm25_docs: list, faiss_docs: list, top_k: int) -> list:
     dedup キーにソースパスと全文を使うことで、同一内容の異なるファイル間の
     誤った重複排除を防ぐ。BM25 の結果を優先して先頭に配置する。
     """
-    seen, combined = set(), []
+    seen: set[tuple[str, str]] = set()
+    combined = []
     for doc in bm25_docs + faiss_docs:
-        key = doc.metadata.get("source", "") + "|" + doc.page_content
+        key = (doc.metadata.get("source", ""), doc.page_content)
         if key not in seen:
             seen.add(key)
             combined.append(doc)

--- a/src/rag.py
+++ b/src/rag.py
@@ -7,11 +7,30 @@ import pickle
 
 from langchain_community.retrievers import BM25Retriever
 from langchain_community.vectorstores import FAISS
+from langchain_core.documents import Document
 from langchain_core.output_parsers import StrOutputParser
 from langchain_ollama import ChatOllama, OllamaEmbeddings
 
-from config import EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K
+from config import EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K, PROJECT_ROOT
 from prompts import CONTEXTUALIZE_PROMPT, QA_PROMPT
+
+_DATA_DIR = os.path.join(PROJECT_ROOT, "data")
+
+
+def _assert_safe_path(path: str) -> None:
+    """ファイルパスがデータディレクトリ内の通常ファイルであることを検証する。
+
+    パストラバーサル・シンボリックリンク・ワールドライタブルを拒否する。
+    """
+    real = os.path.realpath(path)
+    data_real = os.path.realpath(_DATA_DIR)
+    if not real.startswith(data_real + os.sep) and real != data_real:
+        raise ValueError(f"安全でないパス: {path}")
+    if os.path.islink(path):
+        raise ValueError(f"シンボリックリンクは許可されていません: {path}")
+    mode = os.stat(real).st_mode
+    if mode & 0o002:
+        raise ValueError(f"ワールドライタブルなファイルは読み込めません: {path}")
 
 
 def _japanese_tokenizer(text: str) -> list[str]:
@@ -59,6 +78,10 @@ def load_resources(
             "パスが信頼済みのローカルファイルであることを確認してから呼び出してください。"
         )
 
+    _assert_safe_path(vectorstore_path)
+    if docs_cache_path and os.path.exists(docs_cache_path):
+        _assert_safe_path(docs_cache_path)
+
     embeddings = OllamaEmbeddings(model=EMBED_MODEL)
     vectorstore = FAISS.load_local(
         vectorstore_path, embeddings,
@@ -90,7 +113,7 @@ def load_resources(
     return llm, hybrid_retrieve
 
 
-def format_docs(docs) -> str:
+def format_docs(docs: list[Document]) -> str:
     """ドキュメントをソース名付きの構造化テキストに整形する。"""
     chunks = []
     for i, doc in enumerate(docs, 1):

--- a/src/rag.py
+++ b/src/rag.py
@@ -1,0 +1,98 @@
+"""RAG パイプライン。Streamlit に依存しない純粋なロジック層。
+
+app.py・query.py の両エントリーポイントから呼び出される。
+"""
+import os
+import pickle
+
+from langchain_community.retrievers import BM25Retriever
+from langchain_community.vectorstores import FAISS
+from langchain_core.output_parsers import StrOutputParser
+from langchain_ollama import ChatOllama, OllamaEmbeddings
+
+from config import EMBED_MODEL, LLM_MODEL, TOP_K, FETCH_K
+from prompts import CONTEXTUALIZE_PROMPT, QA_PROMPT
+
+
+def _japanese_tokenizer(text: str) -> list[str]:
+    """日本語テキストを文字・バイグラム単位でトークナイズする。"""
+    chars = list(text)
+    bigrams = ["".join(chars[i:i + 2]) for i in range(len(chars) - 1)]
+    return chars + bigrams
+
+
+def load_resources(vectorstore_path: str, docs_cache_path: str | None = None):
+    """FAISS・BM25・LLM をロードして (llm, hybrid_retrieve_fn) を返す。
+
+    Args:
+        vectorstore_path: FAISS ベクトルストアのパス。
+        docs_cache_path: BM25 用 pickle キャッシュのパス。None または存在しない場合は BM25 なし。
+
+    Returns:
+        (llm, hybrid_retrieve_fn) のタプル。
+    """
+    embeddings = OllamaEmbeddings(model=EMBED_MODEL)
+    vectorstore = FAISS.load_local(
+        vectorstore_path, embeddings,
+        allow_dangerous_deserialization=True,
+    )
+    faiss_retriever = vectorstore.as_retriever(
+        search_type="mmr",
+        search_kwargs={"k": TOP_K, "fetch_k": FETCH_K},
+    )
+
+    bm25_retriever = None
+    if docs_cache_path and os.path.exists(docs_cache_path):
+        # docs_cache.pkl は ingest.py がローカルの Obsidian Vault から生成する
+        # 信頼済みローカルファイルのため pickle デシリアライズは安全
+        with open(docs_cache_path, "rb") as f:
+            all_docs = pickle.load(f)
+        bm25_retriever = BM25Retriever.from_documents(
+            all_docs, preprocess_func=_japanese_tokenizer
+        )
+        bm25_retriever.k = TOP_K
+
+    def hybrid_retrieve(question: str) -> list:
+        """BM25 と FAISS の結果をマージして重複除去したドキュメントリストを返す。"""
+        faiss_docs = faiss_retriever.invoke(question)
+        if bm25_retriever is None:
+            return faiss_docs
+        bm25_docs = bm25_retriever.invoke(question)
+        seen, combined = set(), []
+        for doc in bm25_docs + faiss_docs:
+            key = doc.page_content[:80]
+            if key not in seen:
+                seen.add(key)
+                combined.append(doc)
+        return combined[:TOP_K]
+
+    llm = ChatOllama(model=LLM_MODEL, temperature=0.1)
+    return llm, hybrid_retrieve
+
+
+def format_docs(docs) -> str:
+    """ドキュメントをソース名付きの構造化テキストに整形する。"""
+    chunks = []
+    for i, doc in enumerate(docs, 1):
+        source = os.path.basename(doc.metadata.get("source", "unknown"))
+        chunks.append(f"=== Source {i}: {source} ===\n{doc.page_content}\n---")
+    return "\n\n".join(chunks)
+
+
+def contextualize_query(llm, question: str, chat_history: list) -> str:
+    """会話履歴があるときフォローアップ質問を単独の質問に言い換える。
+
+    履歴がない場合は LLM を呼ばずそのまま返す。
+    """
+    if not chat_history:
+        return question
+    return (CONTEXTUALIZE_PROMPT | llm | StrOutputParser()).invoke(
+        {"input": question, "chat_history": chat_history}
+    )
+
+
+def stream_answer(llm, question: str, chat_history: list, docs: list):
+    """QA チェーンの回答をトークン単位でストリーム返却するジェネレータ。"""
+    yield from (QA_PROMPT | llm | StrOutputParser()).stream(
+        {"input": question, "chat_history": chat_history, "context": format_docs(docs)}
+    )

--- a/src/rag.py
+++ b/src/rag.py
@@ -21,16 +21,43 @@ def _japanese_tokenizer(text: str) -> list[str]:
     return chars + bigrams
 
 
-def load_resources(vectorstore_path: str, docs_cache_path: str | None = None):
+def _merge_results(bm25_docs: list, faiss_docs: list, top_k: int) -> list:
+    """BM25 と FAISS の結果をマージして重複除去したドキュメントリストを返す。
+
+    dedup キーにソースパスと全文を使うことで、同一内容の異なるファイル間の
+    誤った重複排除を防ぐ。BM25 の結果を優先して先頭に配置する。
+    """
+    seen, combined = set(), []
+    for doc in bm25_docs + faiss_docs:
+        key = doc.metadata.get("source", "") + "|" + doc.page_content
+        if key not in seen:
+            seen.add(key)
+            combined.append(doc)
+    return combined[:top_k]
+
+
+def load_resources(
+    vectorstore_path: str,
+    docs_cache_path: str | None = None,
+    allow_deserialization: bool = False,
+):
     """FAISS・BM25・LLM をロードして (llm, hybrid_retrieve_fn) を返す。
 
     Args:
         vectorstore_path: FAISS ベクトルストアのパス。
         docs_cache_path: BM25 用 pickle キャッシュのパス。None または存在しない場合は BM25 なし。
+        allow_deserialization: FAISS および pickle の逆シリアライズを許可する場合は True。
+            呼び出し元がパスの安全性を確認済みであることを明示するフラグ。
 
     Returns:
         (llm, hybrid_retrieve_fn) のタプル。
     """
+    if not allow_deserialization:
+        raise ValueError(
+            "allow_deserialization=True を明示的に指定してください。"
+            "パスが信頼済みのローカルファイルであることを確認してから呼び出してください。"
+        )
+
     embeddings = OllamaEmbeddings(model=EMBED_MODEL)
     vectorstore = FAISS.load_local(
         vectorstore_path, embeddings,
@@ -43,8 +70,6 @@ def load_resources(vectorstore_path: str, docs_cache_path: str | None = None):
 
     bm25_retriever = None
     if docs_cache_path and os.path.exists(docs_cache_path):
-        # docs_cache.pkl は ingest.py がローカルの Obsidian Vault から生成する
-        # 信頼済みローカルファイルのため pickle デシリアライズは安全
         with open(docs_cache_path, "rb") as f:
             all_docs = pickle.load(f)
         bm25_retriever = BM25Retriever.from_documents(
@@ -58,13 +83,7 @@ def load_resources(vectorstore_path: str, docs_cache_path: str | None = None):
         if bm25_retriever is None:
             return faiss_docs
         bm25_docs = bm25_retriever.invoke(question)
-        seen, combined = set(), []
-        for doc in bm25_docs + faiss_docs:
-            key = doc.page_content[:80]
-            if key not in seen:
-                seen.add(key)
-                combined.append(doc)
-        return combined[:TOP_K]
+        return _merge_results(bm25_docs, faiss_docs, TOP_K)
 
     llm = ChatOllama(model=LLM_MODEL, temperature=0.1)
     return llm, hybrid_retrieve

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -14,7 +14,7 @@ from rag import format_docs, contextualize_query, stream_answer, _merge_results,
 # ── load_resources ────────────────────────────────────────
 
 def test_load_resources_requires_allow_deserialization():
-    """allow_deserialization=False（デフォルト）では ValueError を送出する。"""
+    """allow_deserialization=False (デフォルト) では ValueError を送出する。"""
     with pytest.raises(ValueError, match="allow_deserialization"):
         load_resources("/any/path")
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -8,7 +8,48 @@ from langchain_core.documents import Document
 from langchain_core.language_models.fake import FakeListLLM
 from langchain_core.messages import HumanMessage, AIMessage
 
-from rag import format_docs, contextualize_query, stream_answer
+from rag import format_docs, contextualize_query, stream_answer, _merge_results, load_resources
+
+
+# ── load_resources ────────────────────────────────────────
+
+def test_load_resources_requires_allow_deserialization():
+    """allow_deserialization=False（デフォルト）では ValueError を送出する。"""
+    with pytest.raises(ValueError, match="allow_deserialization"):
+        load_resources("/any/path")
+
+
+# ── _merge_results ─────────────────────────────────────────
+
+def test_merge_results_deduplicates_same_source_and_content():
+    """同じソースと本文を持つドキュメントは重複除去される。"""
+    doc = Document(page_content="text", metadata={"source": "a.md"})
+    duplicate = Document(page_content="text", metadata={"source": "a.md"})
+    result = _merge_results([doc], [duplicate], top_k=10)
+    assert len(result) == 1
+
+
+def test_merge_results_keeps_same_content_different_source():
+    """同じ本文でもソースが異なれば別ドキュメントとして保持する。"""
+    doc1 = Document(page_content="text", metadata={"source": "a.md"})
+    doc2 = Document(page_content="text", metadata={"source": "b.md"})
+    result = _merge_results([doc1], [doc2], top_k=10)
+    assert len(result) == 2
+
+
+def test_merge_results_bm25_first():
+    """BM25 の結果が先頭に来る。"""
+    bm25_doc = Document(page_content="bm25", metadata={"source": "a.md"})
+    faiss_doc = Document(page_content="faiss", metadata={"source": "b.md"})
+    result = _merge_results([bm25_doc], [faiss_doc], top_k=10)
+    assert result[0].page_content == "bm25"
+
+
+def test_merge_results_respects_top_k():
+    """top_k で上限を超えないことを確認。"""
+    docs = [Document(page_content=f"doc{i}", metadata={"source": f"{i}.md"}) for i in range(6)]
+    result = _merge_results(docs[:3], docs[3:], top_k=4)
+    assert len(result) == 4
 
 
 # ── format_docs ────────────────────────────────────────────

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from langchain_core.documents import Document
+from langchain_core.language_models.fake import FakeListLLM
+from langchain_core.messages import HumanMessage, AIMessage
+
+from rag import format_docs, contextualize_query, stream_answer
+
+
+# ── format_docs ────────────────────────────────────────────
+
+def test_format_docs_empty():
+    assert format_docs([]) == ""
+
+
+def test_format_docs_includes_basename():
+    doc = Document(page_content="本文", metadata={"source": "/path/to/note.md"})
+    result = format_docs([doc])
+    assert "note.md" in result
+    assert "本文" in result
+
+
+def test_format_docs_multiple_docs():
+    docs = [
+        Document(page_content="A", metadata={"source": "a.md"}),
+        Document(page_content="B", metadata={"source": "b.md"}),
+    ]
+    result = format_docs(docs)
+    assert "Source 1" in result
+    assert "Source 2" in result
+    assert "a.md" in result
+    assert "b.md" in result
+
+
+# ── contextualize_query ────────────────────────────────────
+
+def test_contextualize_query_no_history_skips_llm():
+    """履歴なしの場合は LLM を呼ばずそのまま返す。"""
+    llm = FakeListLLM(responses=["LLM が呼ばれたら失敗"])
+    result = contextualize_query(llm, "元の質問", [])
+    assert result == "元の質問"
+
+
+def test_contextualize_query_with_history_calls_llm():
+    """履歴ありの場合は LLM で言い換えた質問を返す。"""
+    llm = FakeListLLM(responses=["言い換えた質問"])
+    chat_history = [HumanMessage(content="前の質問"), AIMessage(content="前の回答")]
+    result = contextualize_query(llm, "それについて詳しく", chat_history)
+    assert result == "言い換えた質問"
+
+
+# ── stream_answer ──────────────────────────────────────────
+
+def test_stream_answer_yields_chunks():
+    llm = FakeListLLM(responses=["回答テキスト"])
+    docs = [Document(page_content="コンテキスト", metadata={"source": "test.md"})]
+    chunks = list(stream_answer(llm, "質問", [], docs))
+    assert "".join(chunks) == "回答テキスト"
+
+
+def test_stream_answer_with_history():
+    llm = FakeListLLM(responses=["履歴あり回答"])
+    docs = [Document(page_content="ctx", metadata={"source": "n.md"})]
+    chat_history = [HumanMessage(content="Q1"), AIMessage(content="A1")]
+    chunks = list(stream_answer(llm, "Q2", chat_history, docs))
+    assert "".join(chunks) == "履歴あり回答"


### PR DESCRIPTION
## Summary

- `src/rag.py` (new) — Streamlit に依存しない純粋な RAG ロジック層
  - `load_resources()` — FAISS・BM25・LLM のロード
  - `format_docs()` — ドキュメントの整形
  - `contextualize_query()` — フォローアップ質問の言い換え
  - `stream_answer()` — トークンのストリーム生成
- `src/app.py` — UI のみに絞り込み。`@st.cache_resource` ラッパーと描画のみ
- `src/query.py` — `rag.py` を呼ぶ薄い CLI シェル。トークンを逐次 stdout に出力
- `tests/test_rag.py` (new) — `rag.py` の7テスト（FakeListLLM 使用）

## Test plan

- [x] 33 tests pass (26 existing + 7 new for rag.py)
- [x] `format_docs` — 空・単一・複数ドキュメント
- [x] `contextualize_query` — 履歴なし（LLM スキップ）・履歴あり（LLM 呼び出し）
- [x] `stream_answer` — 通常・履歴ありの両ケース

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retrieval, query contextualization, and streaming now live in a shared RAG component; the app and CLI delegate to it, simplifying internals and enabling consistent behavior.

* **New Features**
  * CLI now emits streamed answer chunks to stdout for faster incremental feedback.
  * Query contextualization will rewrite questions when chat history exists, preserving original when absent.

* **Tests**
  * Added unit tests covering loading guard, result merging/deduplication/order, document formatting, contextualization, and streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->