### PR TITLE
fix: Prevent response loss when switching sessions during LLM processing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`local-rag` is a fully local RAG system for querying Obsidian vaults. All processing is offline using Ollama for embedding and LLM inference. It combines BM25 keyword search + FAISS vector search (MMR) with a Streamlit chat UI and SQLite-backed chat history.
+
+## Prerequisites
+
+```bash
+brew install ollama
+ollama serve           # must be running before ingest or query
+ollama pull nomic-embed-text
+ollama pull qwen2.5:7b
+```
+
+## Commands
+
+```bash
+# Setup
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# Ingest Obsidian vault (run from src/)
+cd src && python ingest.py
+
+# Query via CLI (run from src/)
+cd src && python query.py "your question"
+
+# Start Streamlit UI (run from src/, opens http://localhost:8501)
+cd src && streamlit run app.py
+
+# Run all tests
+pytest tests/ -v
+
+# Run a single test file
+pytest tests/test_session_repo.py -v
+
+# Run a single test
+pytest tests/test_session_repo.py::test_create_session -v
+```
+
+## Architecture
+
+### Data Flow
+
+```
+Obsidian Vault → ObsidianLoader → RecursiveCharacterTextSplitter (500 chars, 100 overlap)
+    ├── FAISS vectorstore  (nomic-embed-text embeddings, saved to data/vectorstore/)
+    └── BM25 cache         (pickled docs, saved to data/docs_cache.pkl)
+
+User Query → Hybrid retrieval (BM25 + FAISS/MMR) → deduplicate → TOP_K=6 chunks
+    → Prompt (src/prompts.py) + qwen2.5:7b → Streamed answer
+    → SQLite (data/chat.db) for session persistence
+```
+
+### Key Modules
+
+| File | Role |
+|------|------|
+| `src/config.py` | Central config — all paths, model names, tuning params (edit here first) |
+| `src/ingest.py` | One-time vault ingestion; must re-run after vault changes |
+| `src/app.py` | Streamlit UI; hybrid retrieval, session management, export |
+| `src/query.py` | CLI interface using FAISS only (no BM25) |
+| `src/db/` | SQLite layer: `connection.py`, `models.py`, `session_repo.py`, `message_repo.py`, `export.py` |
+
+### Hybrid Search (src/app.py)
+
+BM25 uses a custom Japanese tokenizer (`japanese_tokenizer()`) that produces character unigrams and bigrams to support Japanese text. Results from BM25 and FAISS are merged and deduplicated before passing to the LLM.
+
+### Configuration (src/config.py)
+
+Key tuning parameters:
+- `OBSIDIAN_VAULT_PATH` — set this to your vault location
+- `CHUNK_SIZE` / `CHUNK_OVERLAP` — affects recall vs. context noise
+- `MAX_CHUNK_CHARS` = 1500 — truncates chunks to avoid LLM context overflow
+- `TOP_K` = 6, `FETCH_K` = 20 — MMR diversity controls
+- `LLM_MODEL` — switch to `qwen2.5:14b` for better quality on M-series with Metal GPU
+
+### Database Schema
+
+```sql
+sessions (id TEXT PRIMARY KEY, title TEXT, created_at DATETIME)
+messages (id, session_id → sessions(id) ON DELETE CASCADE, role CHECK('user'|'assistant'), content, created_at)
+```
+
+Tests use an in-memory SQLite fixture (`conftest.py::tmp_db`) — no real DB is touched during test runs.
+
+## Coding Conventions
+
+### Modularization
+
+**Each file must have a single, clearly defined responsibility. Do not place multiple unrelated concerns in the same file.**
+
+| Responsibility | Where it belongs |
+|----------------|-----------------|
+| RAG pipeline logic (retrieval, prompts, LLM calls) | `src/rag.py` |
+| Streamlit UI and user interaction | `src/app.py` |
+| Logging configuration | `src/log_config.py` |
+| Central config and constants | `src/config.py` |
+| DB connection | `src/db/connection.py` |
+| DB schema / migrations | `src/db/models.py` |
+| Session CRUD | `src/db/session_repo.py` |
+| Message CRUD | `src/db/message_repo.py` |
+| Export helpers | `src/db/export.py` |
+
+**Rules:**
+- When adding a new cross-cutting concern (logging, metrics, auth, etc.), create a dedicated module rather than embedding the logic in an existing file.
+- `app.py` must remain a thin UI layer — it delegates to `rag.py`, `log_config.py`, and `db/` rather than implementing logic itself.
+- If a function or class does not belong to the current file's stated responsibility, extract it to the appropriate module before adding it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,10 @@ User Query → Hybrid retrieval (BM25 + FAISS/MMR) → deduplicate → TOP_K=6 c
 |------|------|
 | `src/config.py` | Central config — all paths, model names, tuning params (edit here first) |
 | `src/ingest.py` | One-time vault ingestion; must re-run after vault changes |
-| `src/app.py` | Streamlit UI; hybrid retrieval, session management, export |
-| `src/query.py` | CLI interface using FAISS only (no BM25) |
+| `src/app.py` | Streamlit UI — thin layer delegating to rag.py, db/, log_config.py |
+| `src/rag.py` | RAG pipeline — load_resources, make_llm, hybrid retrieve, invoke_answer, stream_answer |
+| `src/query.py` | CLI interface — BM25 + FAISS hybrid (same pipeline as app.py) |
+| `src/log_config.py` | Logging setup — daily rotating file handler (logs/YYYYMMDD-app.log) |
 | `src/db/` | SQLite layer: `connection.py`, `models.py`, `session_repo.py`, `message_repo.py`, `export.py` |
 
 ### Hybrid Search (src/app.py)

--- a/src/app.py
+++ b/src/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import threading
@@ -16,15 +17,30 @@ import rag
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
 # DB 初期化
 init_db()
 
 st.set_page_config(page_title="Obsidian RAG", page_icon="📓", layout="wide")
 
-# バックグラウンドスレッドと Streamlit UI の両方から安全にアクセスできるよう
-# モジュールレベルの set で管理する（st.session_state はスレッドから参照不可）
-_pending_sessions: set[str] = set()
-_pending_lock = threading.Lock()
+
+@st.cache_resource
+def _get_shared_state() -> dict:
+    """Streamlit の rerun をまたいで保持するサーバーグローバルな状態。
+
+    st.session_state はスレッドから参照できないため、バックグラウンドスレッドと
+    UI スレッドの共有データをここで管理する。
+    """
+    return {
+        "pending": set(),          # 処理中の session_id の集合
+        "lock": threading.Lock(),  # pending・status の排他制御
+        "status": {},              # session_id -> 現在の処理ステップ名
+    }
 
 
 @st.cache_resource
@@ -55,19 +71,43 @@ if "session_id" not in st.session_state:
 def _run_chain(session_id: str, question: str, chat_history: list) -> None:
     """バックグラウンドスレッドで RAG チェーンを実行して DB に保存する。
 
-    st.write_stream() はスレッドから使えないため invoke_answer() を使用する。
-    完了・エラーどちらの場合も _pending_sessions から session_id を削除する。
+    各ステップで logger と shared["status"] を更新し、処理状況を追跡できるようにする。
     """
+    shared = _get_shared_state()
+    sid = session_id[:8]
+
+    def _set_status(msg: str) -> None:
+        with shared["lock"]:
+            shared["status"][session_id] = msg
+
     try:
+        logger.info("[%s] chain start — question: %.60s", sid, question)
+
+        _set_status("質問を解析中...")
+        logger.info("[%s] contextualize_query start", sid)
         search_query = rag.contextualize_query(llm, question, chat_history)
+        logger.info("[%s] contextualize_query done → %.60s", sid, search_query)
+
+        _set_status("ノートを検索中...")
+        logger.info("[%s] hybrid_retrieve start", sid)
         source_docs = hybrid_retrieve(search_query)
+        logger.info("[%s] hybrid_retrieve done → %d docs", sid, len(source_docs))
+
+        _set_status("回答を生成中...")
+        logger.info("[%s] invoke_answer start", sid)
         answer = rag.invoke_answer(llm, question, chat_history, source_docs)
+        logger.info("[%s] invoke_answer done → %d chars", sid, len(answer))
+
         save_message(session_id, "assistant", answer)
-    except Exception:
-        pass
+        logger.info("[%s] answer saved to DB", sid)
+
+    except Exception as e:
+        logger.exception("[%s] chain failed: %s", sid, e)
     finally:
-        with _pending_lock:
-            _pending_sessions.discard(session_id)
+        with shared["lock"]:
+            shared["pending"].discard(session_id)
+            shared["status"].pop(session_id, None)
+        logger.info("[%s] chain finished (pending removed)", sid)
 
 
 # ── サイドバー：セッション一覧 ──────────────────────────────
@@ -99,12 +139,13 @@ with st.sidebar:
     st.divider()
     st.markdown("#### 履歴")
 
+    shared = _get_shared_state()
     sessions = current_sessions
     for s in sessions:
         col1, col2 = st.columns([5, 1])
         is_active = s["id"] == st.session_state.session_id
-        with _pending_lock:
-            is_pending = s["id"] in _pending_sessions
+        with shared["lock"]:
+            is_pending = s["id"] in shared["pending"]
         label = f"**{s['title']}**" if is_active else s["title"]
         if is_pending:
             label = f"⏳ {label}"
@@ -127,18 +168,21 @@ st.title("📓 Obsidian ノート検索")
 def _chat_area() -> None:
     """チャット表示エリア。1 秒ごとに DB を再取得して完了した回答を表示する。
 
-    _pending_sessions に現在のセッションが含まれる間は生成中インジケーターを表示する。
+    _pending_sessions に現在のセッションが含まれる間は処理ステップを表示する。
     """
+    shared = _get_shared_state()
     messages = get_messages(st.session_state.session_id)
     for msg in messages:
         with st.chat_message(msg["role"]):
             st.markdown(msg["content"])
 
-    with _pending_lock:
-        is_pending = st.session_state.session_id in _pending_sessions
+    with shared["lock"]:
+        is_pending = st.session_state.session_id in shared["pending"]
+        status_msg = shared["status"].get(st.session_state.session_id, "処理中...")
+
     if is_pending:
         with st.chat_message("assistant"):
-            st.markdown("⏳ 回答を生成中...")
+            st.markdown(f"⏳ {status_msg}")
 
 
 _chat_area()
@@ -146,6 +190,9 @@ _chat_area()
 # 入力欄
 if question := st.chat_input("Obsidian ノートに質問する..."):
     session_id = st.session_state.session_id
+    shared = _get_shared_state()
+
+    logger.info("[%s] user submitted: %.60s", session_id[:8], question)
 
     # 現在の会話履歴を取得（新しいユーザー質問は含まない）
     history = AppChatMessageHistory(session_id, max_turns=CHAT_HISTORY_TURNS)
@@ -154,17 +201,21 @@ if question := st.chat_input("Obsidian ノートに質問する..."):
 
     # ユーザーメッセージを即時 DB に保存（セッション切替が発生しても消えない）
     save_message(session_id, "user", question)
+    logger.info("[%s] user message saved to DB", session_id[:8])
 
     if is_first_message:
         update_session_title(session_id, question[:40])
 
     # バックグラウンドスレッドで LLM 処理を実行
-    with _pending_lock:
-        _pending_sessions.add(session_id)
+    with shared["lock"]:
+        shared["pending"].add(session_id)
+        shared["status"][session_id] = "質問を解析中..."
+
     threading.Thread(
         target=_run_chain,
         args=(session_id, question, chat_history),
         daemon=True,
     ).start()
+    logger.info("[%s] background thread started", session_id[:8])
 
     st.rerun()

--- a/src/app.py
+++ b/src/app.py
@@ -60,9 +60,10 @@ if not os.path.exists(VECTORSTORE_PATH):
 if not os.path.exists(DOCS_CACHE_PATH):
     st.warning("BM25用のキャッシュがありません。`python ingest.py` を再実行してください。")
 
-hybrid_retrieve = _load_cached_resources()
-if hybrid_retrieve is None:
-    st.error("リソースのロードに失敗しました。`python ingest.py` を実行してください。")
+try:
+    hybrid_retrieve = _load_cached_resources()
+except Exception as e:
+    st.error(f"リソースのロードに失敗しました: {e}")
     st.stop()
 
 # ── セッション初期化 ────────────────────────────────────────

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 import threading
-from datetime import datetime
 
 import streamlit as st
 from langchain_core.messages import HumanMessage, AIMessage
@@ -14,39 +13,14 @@ from db import (
     get_messages, AppChatMessageHistory, save_message,
     build_export_content, export_filename,
 )
+from log_config import setup_logging
 import rag
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
 LOG_DIR = os.path.join(PROJECT_ROOT, "logs")
 
+setup_logging(LOG_DIR)
 logger = logging.getLogger(__name__)
-
-
-@st.cache_resource
-def _setup_logging() -> None:
-    """ロギングをサーバー起動時に1回だけ設定する。
-
-    logs/<YYYYMMDD>-app.log に追記しつつ、コンソールにも同時出力する。
-    @st.cache_resource により Streamlit のリランをまたいで重複追加されない。
-    """
-    os.makedirs(LOG_DIR, exist_ok=True)
-    log_file = os.path.join(LOG_DIR, datetime.now().strftime("%Y%m%d") + "-app.log")
-
-    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
-
-    file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
-    file_handler.setFormatter(fmt)
-
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(fmt)
-
-    root = logging.getLogger()
-    root.setLevel(logging.INFO)
-    root.addHandler(file_handler)
-    root.addHandler(stream_handler)
-
-
-_setup_logging()
 
 # DB 初期化
 init_db()

--- a/src/app.py
+++ b/src/app.py
@@ -44,7 +44,11 @@ def _get_shared_state() -> dict:
 
 @st.cache_resource
 def _load_cached_resources():
-    """RAG リソースをロードしてキャッシュする。パス検証は load_resources() 内で実施。"""
+    """ベクトルストアと BM25 リトリーバーをロードしてキャッシュする。
+
+    LLM は ChatOllama のスレッドセーフ性が保証されないため、ここではキャッシュせず
+    スレッドごとに rag.make_llm() で新規生成する。
+    """
     return rag.load_resources(VECTORSTORE_PATH, DOCS_CACHE_PATH, allow_deserialization=True)
 
 
@@ -56,8 +60,8 @@ if not os.path.exists(VECTORSTORE_PATH):
 if not os.path.exists(DOCS_CACHE_PATH):
     st.warning("BM25用のキャッシュがありません。`python ingest.py` を再実行してください。")
 
-llm, hybrid_retrieve = _load_cached_resources()
-if llm is None:
+hybrid_retrieve = _load_cached_resources()
+if hybrid_retrieve is None:
     st.error("リソースのロードに失敗しました。`python ingest.py` を実行してください。")
     st.stop()
 
@@ -82,6 +86,9 @@ def _run_chain(session_id: str, question: str, chat_history: list) -> None:
     try:
         logger.info("[%s] chain start — question: %.60s", sid, question)
 
+        # スレッドごとに新しい LLM インスタンスを生成（ChatOllama のスレッドセーフ性確保）
+        llm = rag.make_llm()
+
         _set_status("質問を解析中...")
         logger.info("[%s] contextualize_query start", sid)
         search_query = rag.contextualize_query(llm, question, chat_history)
@@ -102,6 +109,10 @@ def _run_chain(session_id: str, question: str, chat_history: list) -> None:
 
     except Exception as e:
         logger.exception("[%s] chain failed: %s", sid, e)
+        try:
+            save_message(session_id, "assistant", "⚠️ エラーが発生しました。もう一度お試しください。")
+        except Exception:
+            logger.exception("[%s] failed to save error message", sid)
     finally:
         with shared["lock"]:
             shared["pending"].discard(session_id)
@@ -186,19 +197,24 @@ def _chat_area() -> None:
 
 _chat_area()
 
-# 入力欄
-if question := st.chat_input("Obsidian ノートに質問する..."):
+# 入力欄：処理中はインプットを無効化して多重送信を防ぐ
+shared = _get_shared_state()
+with shared["lock"]:
+    _current_pending = st.session_state.session_id in shared["pending"]
+
+if _current_pending:
+    st.chat_input("処理中です...", disabled=True)
+elif question := st.chat_input("Obsidian ノートに質問する..."):
     session_id = st.session_state.session_id
-    shared = _get_shared_state()
 
     logger.info("[%s] user submitted: %.60s", session_id[:8], question)
 
-    # 現在の会話履歴を取得（新しいユーザー質問は含まない）
+    # 現在の会話履歴を取得 (新しいユーザー質問は含まない)
     history = AppChatMessageHistory(session_id, max_turns=CHAT_HISTORY_TURNS)
     chat_history = history.messages
     is_first_message = len(chat_history) == 0
 
-    # ユーザーメッセージを即時 DB に保存（セッション切替が発生しても消えない）
+    # ユーザーメッセージを即時 DB に保存 (セッション切替が発生しても消えない)
     save_message(session_id, "user", question)
     logger.info("[%s] user message saved to DB", session_id[:8])
 

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,11 @@ init_db()
 
 st.set_page_config(page_title="Obsidian RAG", page_icon="📓", layout="wide")
 
+# バックグラウンドスレッドと Streamlit UI の両方から安全にアクセスできるよう
+# モジュールレベルの set で管理する（st.session_state はスレッドから参照不可）
+_pending_sessions: set[str] = set()
+_pending_lock = threading.Lock()
+
 
 @st.cache_resource
 def _load_cached_resources():
@@ -46,16 +51,12 @@ if "session_id" not in st.session_state:
     recent = list_sessions()
     st.session_state.session_id = recent[0]["id"] if recent else create_session()
 
-# バックグラウンド処理中のセッション ID を追跡する
-if "pending_sessions" not in st.session_state:
-    st.session_state.pending_sessions = set()
-
 
 def _run_chain(session_id: str, question: str, chat_history: list) -> None:
     """バックグラウンドスレッドで RAG チェーンを実行して DB に保存する。
 
     st.write_stream() はスレッドから使えないため invoke_answer() を使用する。
-    完了・エラーどちらの場合も pending_sessions から session_id を削除する。
+    完了・エラーどちらの場合も _pending_sessions から session_id を削除する。
     """
     try:
         search_query = rag.contextualize_query(llm, question, chat_history)
@@ -65,7 +66,8 @@ def _run_chain(session_id: str, question: str, chat_history: list) -> None:
     except Exception:
         pass
     finally:
-        st.session_state.pending_sessions.discard(session_id)
+        with _pending_lock:
+            _pending_sessions.discard(session_id)
 
 
 # ── サイドバー：セッション一覧 ──────────────────────────────
@@ -101,7 +103,8 @@ with st.sidebar:
     for s in sessions:
         col1, col2 = st.columns([5, 1])
         is_active = s["id"] == st.session_state.session_id
-        is_pending = s["id"] in st.session_state.pending_sessions
+        with _pending_lock:
+            is_pending = s["id"] in _pending_sessions
         label = f"**{s['title']}**" if is_active else s["title"]
         if is_pending:
             label = f"⏳ {label}"
@@ -124,14 +127,16 @@ st.title("📓 Obsidian ノート検索")
 def _chat_area() -> None:
     """チャット表示エリア。1 秒ごとに DB を再取得して完了した回答を表示する。
 
-    pending_sessions に現在のセッションが含まれる間は生成中インジケーターを表示する。
+    _pending_sessions に現在のセッションが含まれる間は生成中インジケーターを表示する。
     """
     messages = get_messages(st.session_state.session_id)
     for msg in messages:
         with st.chat_message(msg["role"]):
             st.markdown(msg["content"])
 
-    if st.session_state.session_id in st.session_state.pending_sessions:
+    with _pending_lock:
+        is_pending = st.session_state.session_id in _pending_sessions
+    if is_pending:
         with st.chat_message("assistant"):
             st.markdown("⏳ 回答を生成中...")
 
@@ -154,7 +159,8 @@ if question := st.chat_input("Obsidian ノートに質問する..."):
         update_session_title(session_id, question[:40])
 
     # バックグラウンドスレッドで LLM 処理を実行
-    st.session_state.pending_sessions.add(session_id)
+    with _pending_lock:
+        _pending_sessions.add(session_id)
     threading.Thread(
         target=_run_chain,
         args=(session_id, question, chat_history),

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import threading
+from datetime import datetime
 
 import streamlit as st
 from langchain_core.messages import HumanMessage, AIMessage
@@ -16,12 +17,36 @@ from db import (
 import rag
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
+LOG_DIR = os.path.join(PROJECT_ROOT, "logs")
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-)
 logger = logging.getLogger(__name__)
+
+
+@st.cache_resource
+def _setup_logging() -> None:
+    """ロギングをサーバー起動時に1回だけ設定する。
+
+    logs/<YYYYMMDD>-app.log に追記しつつ、コンソールにも同時出力する。
+    @st.cache_resource により Streamlit のリランをまたいで重複追加されない。
+    """
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log_file = os.path.join(LOG_DIR, datetime.now().strftime("%Y%m%d") + "-app.log")
+
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+    file_handler.setFormatter(fmt)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(fmt)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    root.addHandler(stream_handler)
+
+
+_setup_logging()
 
 # DB 初期化
 init_db()

--- a/src/app.py
+++ b/src/app.py
@@ -1,16 +1,20 @@
 import os
 import sys
+import threading
 
 import streamlit as st
 from langchain_core.messages import HumanMessage, AIMessage
 
 sys.path.insert(0, os.path.dirname(__file__))
 from config import VECTORSTORE_PATH, PROJECT_ROOT, EMBED_MODEL, LLM_MODEL, CHAT_HISTORY_TURNS
-from db import init_db, create_session, list_sessions, delete_session, update_session_title, get_messages, AppChatMessageHistory, build_export_content, export_filename
+from db import (
+    init_db, create_session, list_sessions, delete_session, update_session_title,
+    get_messages, AppChatMessageHistory, save_message,
+    build_export_content, export_filename,
+)
 import rag
 
 DOCS_CACHE_PATH = os.path.join(PROJECT_ROOT, "data", "docs_cache.pkl")
-
 
 # DB 初期化
 init_db()
@@ -38,10 +42,31 @@ if llm is None:
     st.stop()
 
 # ── セッション初期化 ────────────────────────────────────────
-# 再起動後は直近セッションを復元し、存在しない場合のみ新規作成
 if "session_id" not in st.session_state:
     recent = list_sessions()
     st.session_state.session_id = recent[0]["id"] if recent else create_session()
+
+# バックグラウンド処理中のセッション ID を追跡する
+if "pending_sessions" not in st.session_state:
+    st.session_state.pending_sessions = set()
+
+
+def _run_chain(session_id: str, question: str, chat_history: list) -> None:
+    """バックグラウンドスレッドで RAG チェーンを実行して DB に保存する。
+
+    st.write_stream() はスレッドから使えないため invoke_answer() を使用する。
+    完了・エラーどちらの場合も pending_sessions から session_id を削除する。
+    """
+    try:
+        search_query = rag.contextualize_query(llm, question, chat_history)
+        source_docs = hybrid_retrieve(search_query)
+        answer = rag.invoke_answer(llm, question, chat_history, source_docs)
+        save_message(session_id, "assistant", answer)
+    except Exception:
+        pass
+    finally:
+        st.session_state.pending_sessions.discard(session_id)
+
 
 # ── サイドバー：セッション一覧 ──────────────────────────────
 with st.sidebar:
@@ -56,7 +81,10 @@ with st.sidebar:
 
     # 現在のセッションをエクスポート
     current_sessions = list_sessions()
-    current_title = next((s["title"] for s in current_sessions if s["id"] == st.session_state.session_id), "chat")
+    current_title = next(
+        (s["title"] for s in current_sessions if s["id"] == st.session_state.session_id),
+        "chat",
+    )
     export_content = build_export_content(st.session_state.session_id, current_title)
     st.download_button(
         label="📥 エクスポート",
@@ -73,7 +101,10 @@ with st.sidebar:
     for s in sessions:
         col1, col2 = st.columns([5, 1])
         is_active = s["id"] == st.session_state.session_id
+        is_pending = s["id"] in st.session_state.pending_sessions
         label = f"**{s['title']}**" if is_active else s["title"]
+        if is_pending:
+            label = f"⏳ {label}"
         if col1.button(label, key=f"sel_{s['id']}", use_container_width=True):
             st.session_state.session_id = s["id"]
             st.rerun()
@@ -84,52 +115,50 @@ with st.sidebar:
                 st.session_state.session_id = remaining[0]["id"] if remaining else create_session()
             st.rerun()
 
+
 # ── メインエリア ────────────────────────────────────────────
 st.title("📓 Obsidian ノート検索")
 
-# DB からメッセージ復元
-messages = get_messages(st.session_state.session_id)
-for msg in messages:
-    with st.chat_message(msg["role"]):
-        st.markdown(msg["content"])
+
+@st.fragment(run_every=1)
+def _chat_area() -> None:
+    """チャット表示エリア。1 秒ごとに DB を再取得して完了した回答を表示する。
+
+    pending_sessions に現在のセッションが含まれる間は生成中インジケーターを表示する。
+    """
+    messages = get_messages(st.session_state.session_id)
+    for msg in messages:
+        with st.chat_message(msg["role"]):
+            st.markdown(msg["content"])
+
+    if st.session_state.session_id in st.session_state.pending_sessions:
+        with st.chat_message("assistant"):
+            st.markdown("⏳ 回答を生成中...")
+
+
+_chat_area()
 
 # 入力欄
 if question := st.chat_input("Obsidian ノートに質問する..."):
-    history = AppChatMessageHistory(st.session_state.session_id, max_turns=CHAT_HISTORY_TURNS)
+    session_id = st.session_state.session_id
+
+    # 現在の会話履歴を取得（新しいユーザー質問は含まない）
+    history = AppChatMessageHistory(session_id, max_turns=CHAT_HISTORY_TURNS)
     chat_history = history.messages
     is_first_message = len(chat_history) == 0
 
-    with st.chat_message("user"):
-        st.markdown(question)
+    # ユーザーメッセージを即時 DB に保存（セッション切替が発生しても消えない）
+    save_message(session_id, "user", question)
 
     if is_first_message:
-        update_session_title(st.session_state.session_id, question[:40])
+        update_session_title(session_id, question[:40])
 
-    with st.chat_message("assistant"):
-        if chat_history:
-            with st.spinner("質問を解析中..."):
-                search_query = rag.contextualize_query(llm, question, chat_history)
-        else:
-            search_query = question
+    # バックグラウンドスレッドで LLM 処理を実行
+    st.session_state.pending_sessions.add(session_id)
+    threading.Thread(
+        target=_run_chain,
+        args=(session_id, question, chat_history),
+        daemon=True,
+    ).start()
 
-        with st.spinner("ノートを検索中..."):
-            source_docs = hybrid_retrieve(search_query)
-
-        answer = ""
-        try:
-            answer = st.write_stream(rag.stream_answer(llm, question, chat_history, source_docs))
-        except Exception:
-            st.error("回答の生成に失敗しました。Ollama が起動しているか確認してください。")
-            raise
-        finally:
-            history.add_message(HumanMessage(content=question))
-            if answer:
-                history.add_message(AIMessage(content=answer))
-
-        with st.expander("📎 参照したノート"):
-            for i, doc in enumerate(source_docs, 1):
-                source = doc.metadata.get("source", "不明")
-                filename = os.path.basename(source)
-                st.markdown(f"**{i}. {filename}**")
-                st.text(doc.page_content[:300] + "..." if len(doc.page_content) > 300 else doc.page_content)
-                st.divider()
+    st.rerun()

--- a/src/log_config.py
+++ b/src/log_config.py
@@ -1,0 +1,44 @@
+"""ロギング設定モジュール。
+
+アプリ全体のログ設定を一元管理する。
+logs/<YYYYMMDD>-app.log への追記とコンソール出力を同時に行う。
+"""
+import logging
+import os
+from datetime import datetime
+
+# モジュールは sys.modules にキャッシュされるため、このフラグは
+# Streamlit のリランをまたいでも True のまま保持される
+_initialized = False
+
+
+def setup_logging(log_dir: str) -> None:
+    """ロート logger にファイルハンドラとコンソールハンドラを設定する。
+
+    複数回呼ばれても初回のみ設定する（重複ハンドラ防止）。
+
+    Args:
+        log_dir: ログファイルを出力するディレクトリのパス。存在しない場合は作成する。
+    """
+    global _initialized
+    if _initialized:
+        return
+
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, datetime.now().strftime("%Y%m%d") + "-app.log")
+
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+    file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+    file_handler.setFormatter(fmt)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(fmt)
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(file_handler)
+    root.addHandler(stream_handler)
+
+    _initialized = True
+    logging.getLogger(__name__).info("Logging initialized → %s", log_file)

--- a/src/query.py
+++ b/src/query.py
@@ -15,9 +15,10 @@ def query(question: str) -> None:
 
     print(f"🔍 質問: {question}\n")
 
-    llm, retrieve = rag.load_resources(
+    retrieve = rag.load_resources(
         VECTORSTORE_PATH, DOCS_CACHE_PATH, allow_deserialization=True
     )
+    llm = rag.make_llm()
     docs = retrieve(question)
     print("💬 回答:")
     for chunk in rag.stream_answer(llm, question, [], docs):

--- a/src/rag.py
+++ b/src/rag.py
@@ -109,8 +109,16 @@ def load_resources(
         bm25_docs = bm25_retriever.invoke(question)
         return _merge_results(bm25_docs, faiss_docs, TOP_K)
 
-    llm = ChatOllama(model=LLM_MODEL, temperature=0.1)
-    return llm, hybrid_retrieve
+    return hybrid_retrieve
+
+
+def make_llm() -> ChatOllama:
+    """呼び出しごとに新しい ChatOllama インスタンスを返す。
+
+    ChatOllama は同一インスタンスを複数スレッドで共有すると安全でないため、
+    バックグラウンドスレッドから呼び出す際は必ずこの関数で取得する。
+    """
+    return ChatOllama(model=LLM_MODEL, temperature=0.1)
 
 
 def format_docs(docs: list[Document]) -> str:

--- a/src/rag.py
+++ b/src/rag.py
@@ -139,3 +139,14 @@ def stream_answer(llm, question: str, chat_history: list, docs: list):
     yield from (QA_PROMPT | llm | StrOutputParser()).stream(
         {"input": question, "chat_history": chat_history, "context": format_docs(docs)}
     )
+
+
+def invoke_answer(llm, question: str, chat_history: list, docs: list) -> str:
+    """QA チェーンを invoke で実行して回答全文を返す。
+
+    stream_answer() の代替。バックグラウンドスレッドから呼び出す場合など、
+    st.write_stream() が使えない状況で使用する。
+    """
+    return (QA_PROMPT | llm | StrOutputParser()).invoke(
+        {"input": question, "chat_history": chat_history, "context": format_docs(docs)}
+    )

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -8,7 +8,7 @@ from langchain_core.documents import Document
 from langchain_core.language_models.fake import FakeListLLM
 from langchain_core.messages import HumanMessage, AIMessage
 
-from rag import format_docs, contextualize_query, stream_answer, invoke_answer, _merge_results, load_resources
+from rag import format_docs, contextualize_query, stream_answer, invoke_answer, _merge_results, load_resources, make_llm
 
 
 # ── load_resources ────────────────────────────────────────
@@ -17,6 +17,15 @@ def test_load_resources_requires_allow_deserialization():
     """allow_deserialization=False (デフォルト) では ValueError を送出する。"""
     with pytest.raises(ValueError, match="allow_deserialization"):
         load_resources("/any/path")
+
+
+def test_make_llm_returns_new_instance():
+    """make_llm() は呼び出しごとに別インスタンスを返す。"""
+    from langchain_ollama import ChatOllama
+    llm1 = make_llm()
+    llm2 = make_llm()
+    assert isinstance(llm1, ChatOllama)
+    assert llm1 is not llm2
 
 
 # ── _merge_results ─────────────────────────────────────────

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -8,7 +8,7 @@ from langchain_core.documents import Document
 from langchain_core.language_models.fake import FakeListLLM
 from langchain_core.messages import HumanMessage, AIMessage
 
-from rag import format_docs, contextualize_query, stream_answer, _merge_results, load_resources
+from rag import format_docs, contextualize_query, stream_answer, invoke_answer, _merge_results, load_resources
 
 
 # ── load_resources ────────────────────────────────────────
@@ -109,3 +109,22 @@ def test_stream_answer_with_history():
     chat_history = [HumanMessage(content="Q1"), AIMessage(content="A1")]
     chunks = list(stream_answer(llm, "Q2", chat_history, docs))
     assert "".join(chunks) == "履歴あり回答"
+
+
+# ── invoke_answer ──────────────────────────────────────────
+
+def test_invoke_answer_returns_string():
+    """invoke_answer は回答全文を文字列で返す。"""
+    llm = FakeListLLM(responses=["invoke回答"])
+    docs = [Document(page_content="コンテキスト", metadata={"source": "test.md"})]
+    result = invoke_answer(llm, "質問", [], docs)
+    assert result == "invoke回答"
+
+
+def test_invoke_answer_with_history():
+    """履歴ありでも invoke_answer は文字列を返す。"""
+    llm = FakeListLLM(responses=["履歴付きinvoke回答"])
+    docs = [Document(page_content="ctx", metadata={"source": "n.md"})]
+    chat_history = [HumanMessage(content="Q1"), AIMessage(content="A1")]
+    result = invoke_answer(llm, "Q2", chat_history, docs)
+    assert result == "履歴付きinvoke回答"


### PR DESCRIPTION
## Summary

- **Root cause**: `st.write_stream()` is cancelled when Streamlit reruns (e.g., sidebar click), so the assistant message was never saved to DB
- **Fix**: Move LLM processing to a background `threading.Thread` so it survives Streamlit reruns
- Save user message to DB **immediately** on submission (before LLM starts)
- Run `rag.invoke_answer()` (non-streaming `.invoke()`) in the background thread — `st.write_stream()` cannot be used from threads
- Track in-progress sessions via `st.session_state.pending_sessions`
- Show ⏳ indicator in sidebar labels and chat area while processing
- Use `@st.fragment(run_every=1)` to poll DB every second and display the answer when complete
- Added `rag.invoke_answer()` and 2 new tests

## Test plan

- [x] 40 tests pass (`pytest tests/ -v`)
- [x] `test_invoke_answer_returns_string` — invoke_answer returns full string
- [x] `test_invoke_answer_with_history` — works with chat history
- [ ] Manual: Ask question → switch session mid-processing → switch back → answer appears in original session

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat processing now runs in background for snappier UI; input is disabled while a session is pending.
  * Pending sessions are marked with ⏳ in the sidebar; chat area shows live step/status updates.
  * Messages are persisted immediately and loaded from the database for rendering.

* **Documentation**
  * Added detailed user/developer setup and architecture guide.

* **Tests**
  * New tests for RAG utilities ensuring fresh model instances and full-answer behavior.

* **Chores**
  * Centralized, idempotent application logging setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->